### PR TITLE
selsign: Update installation permissions on selsign

### DIFF
--- a/src/selsign/Makefile
+++ b/src/selsign/Makefile
@@ -21,4 +21,4 @@ clean:
 
 install: all
 	$(INSTALL) -d -m 755 $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m 700 $(BIN_NAME) $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 755 $(BIN_NAME) $(DESTDIR)$(BINDIR)


### PR DESCRIPTION
Install the selsign binary with mode 755 so that everyone can execute
it.  Masking the permissions of the binary is not the way to protect the
default keys, managing permissions on the default keys is how you need
to do that.

Signed-off-by: Tom Rini <trini@konsulko.com>
---
The motivations behind this is to update meta-secure-core to include nativesdk-libsign for selsign to allow for signing files outside of bitbake.