### PR TITLE
Fix build failure with GCC 8.x

### DIFF
--- a/src/signaturelet/SELoader.c
+++ b/src/signaturelet/SELoader.c
@@ -63,7 +63,7 @@ construct_sel_signature(uint8_t *sig_content, unsigned sig_content_size,
 
 	SEL_SIGNATURE_HEADER header;
 
-	strncpy((char *)&header.Magic, SelSigantureMagic,
+	memcpy((char *)&header.Magic, SelSigantureMagic,
 		sizeof(header.Magic));
 	header.Revision = SelSignatureRevision;
 	header.HeaderSize = sizeof(header);


### PR DESCRIPTION
GCC 8 introduces detecting string truncation, see
https://developers.redhat.com/blog/2018/05/24/detecting-string-truncation-with-gcc-8

And a build failure shows up on Fedora 28 with GCC 8.1, see:
SELoader.c: In function ‘construct_sel_signature’:
SELoader.c:66:2: error: ‘strncpy’ output truncated before terminating
nul copying 4 bytes from a string of the same length [-Werror=stringop-truncation]
  strncpy((char *)&header.Magic, SelSigantureMagic,
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   sizeof(header.Magic));
   ~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors

Replace strncpy with memcpy to address the build failure above,
referring to https://lkml.org/lkml/2018/5/29/174

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>