### PR TITLE
lib/Makefile: set correct soname for libsign

### DIFF
--- a/src/lib/Makefile
+++ b/src/lib/Makefile
@@ -34,7 +34,7 @@ install: all
 	    ln -sfn $(x).$(LIBSIGN_MAJOR_VERSION) $(DESTDIR)$(LIBDIR)/$(patsubst %,%,$(x));)
 
 $(LIB_NAME).so: $(OBJS_$(LIB_NAME))
-	$(CCLD) $^ -o $@ $(CFLAGS) -shared -Wl,-soname,$(patsubst %.$(LIBSIGN_VERSION),%,$@)
+	$(CCLD) $^ -o $@ $(CFLAGS) -shared -Wl,-soname,$(patsubst %,%.$(LIBSIGN_MAJOR_VERSION),$@)
 
 $(LIB_NAME).a: $(OBJS_$(LIB_NAME))
 	$(AR) rcs $@ $^


### PR DESCRIPTION
The current soname of libsign is libsign.so:
$ readelf -d libsign.so.0.3.2 | grep SONA ME
0x000000000000000e (SONAME)    Library soname: [libsign.so]

The libsign.so is a symbolic link of libsign.so.0.3.2 and it is not
installed by default because it is packaged to dev package. Then we will
encounter an error when run command selsign:
$ selsign
selsign: error while loading shared libraries: libsign.so: cannot open shared object file: No such file or directory

$ ldd selsign |grep libsign
    libsign.so => not found

Set the soname to libsign.so.$(LIBSIGN_MAJOR_VERSION) to fix the issue.

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>